### PR TITLE
Gt/switch boundaries back

### DIFF
--- a/src/volcanic_island_simulator.py
+++ b/src/volcanic_island_simulator.py
@@ -35,18 +35,18 @@ _DEFAULT_FLOW_PARAMS = {
 }
 
 _DEFAULT_SPACE_PARAMS = {
-    "K_sed": 0.002, # sediment erodibility
-    "K_br": 0.002, # bedrock erodibility
-    "F_f": 0.0, # fraction of fines
-    "phi": 0.3, # sediment porosity
-    "H_star": 0.1, # characteristic sediment thickness (roughness height)
-    "v_s": 1.0, # settling velocity
-    "m_sp": 0.5, # area exponent in stream power equation
-    "n_sp": 1.0, # slope exponent in stream power equation
-    "sp_crit_sed": 0.0, # threshold to erode sediment?
-    "sp_crit_br": 0.0, # threshold to erode bedrock?
-    "discharge_field": 'surface_water__discharge', 
-    "solver": 'basic', 
+    "K_sed": 0.01,  # sediment erodibility
+    "K_br": 0.0001,  # bedrock erodibility
+    "F_f": 0.0,  # fraction of fines
+    "phi": 0.3,  # sediment porosity
+    "H_star": 0.1,  # characteristic sediment thickness (roughness height)
+    "v_s": 1.0,  # settling velocity
+    "m_sp": 0.5,  # area exponent in stream power equation
+    "n_sp": 1.0,  # slope exponent in stream power equation
+    "sp_crit_sed": 0.0,  # threshold to erode sediment?
+    "sp_crit_br": 0.0,  # threshold to erode bedrock?
+    "discharge_field": "surface_water__discharge",
+    "solver": "basic",
     "dt_min": 0.001,
 }
 
@@ -91,8 +91,10 @@ class VolcanicIslandSimulator:
             relief, angle, self.grid.x_of_node, self.grid.y_of_node, noise
         )
 
-        # ...and soil
-        self.soil = self.grid.add_zeros("soil__depth", at="node")
+        # ...and rock and soil
+        self.rock = self.grid.add_zeros("bedrock__elevation", at="node")
+        self.soil = self.grid.add_zeros("soil__depth", at="node") + 0.01
+        self.rock[:] = self.topo - self.soil
         # For each process/phenomenon, parse parameters, create field(s),
         # instantiate components, and perform other initialization
 
@@ -116,13 +118,14 @@ class VolcanicIslandSimulator:
         self.flow_router = PriorityFloodFlowRouter(self.grid, **flow_params)
 
         #   fluvial erosion, transport, deposition
-        if 'space' in params:
-            space_params = params['space']
-            
+        if "space" in params:
+            space_params = params["space"]
+
         else:
             space_params = _DEFAULT_SPACE_PARAMS
-            
+
         self.space = Space(self.grid, **space_params)
+        self.fluvial_sed_influx = self.space.sediment_influx
 
         #   submarine sediment transport
 
@@ -151,7 +154,12 @@ class VolcanicIslandSimulator:
         # Apply fluvial erosion, transport, and deposition
         self.space.run_one_step()
 
+        # Deposit incoming sediment at underwater nodes
+        sea_node_areas = self.grid.area_of_cell[self.grid.cell_at_node[under_water]]
+        self.soil[under_water] += self.fluvial_sed_influx[under_water] / sea_node_areas
+
         # Switch boundaries back to full grid
+        self.grid.status_at_node[under_water] = self.grid.BC_NODE_IS_CORE
 
         # Apply submarine sediment transport
 

--- a/volcanic_island_model_demo.ipynb
+++ b/volcanic_island_model_demo.ipynb
@@ -42,6 +42,25 @@
     "        'relief': 1500.0,\n",
     "        'angle': 6.0,\n",
     "        'noise': 40.0\n",
+    "    },\n",
+    "    'timing': {\n",
+    "        'run_duration': 1000.0,\n",
+    "        'timestep_size': 1.0\n",
+    "    },\n",
+    "    'space': {\n",
+    "        \"K_sed\": 0.01,  # sediment erodibility\n",
+    "        \"K_br\": 0.0001,  # bedrock erodibility\n",
+    "        \"F_f\": 0.0,  # fraction of fines\n",
+    "        \"phi\": 0.3,  # sediment porosity\n",
+    "        \"H_star\": 0.1,  # characteristic sediment thickness (roughness height)\n",
+    "        \"v_s\": 0.001,  # settling velocity\n",
+    "        \"m_sp\": 0.5,  # area exponent in stream power equation\n",
+    "        \"n_sp\": 1.0,  # slope exponent in stream power equation\n",
+    "        \"sp_crit_sed\": 0.0,  # threshold to erode sediment?\n",
+    "        \"sp_crit_br\": 0.0,  # threshold to erode bedrock?\n",
+    "        \"discharge_field\": \"surface_water__discharge\",\n",
+    "        \"solver\": \"basic\",\n",
+    "        \"dt_min\": 0.001,\n",
     "    }\n",
     "}"
    ]
@@ -53,7 +72,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vsim = VolcanicIslandSimulator(params)"
+    "vsim = VolcanicIslandSimulator(params)\n",
+    "\n",
+    "initial_topo = vsim.topo.copy()"
    ]
   },
   {
@@ -79,8 +100,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5611e59",
+   "id": "ae879322",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "imshow_grid(vsim.grid, vsim.topo - initial_topo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5611e59",
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "imshow_grid(vsim.grid, 'drainage_area')"
@@ -93,13 +126,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vsim = VolcanicIslandSimulator(params)"
+    "imshow_grid(vsim.grid, vsim.topo)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "514e942c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imshow_grid(vsim.grid, vsim.soil)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a71b5a66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(vsim.grid.x_of_node.reshape(81, 81)[41,:], vsim.topo.reshape(81, 81)[41,:])\n",
+    "plt.plot(vsim.grid.x_of_node.reshape(81, 81)[21,:], vsim.topo.reshape(81, 81)[21,:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efcdce49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check mass balance\n",
+    "print('Starting mean topo', np.mean(initial_topo))\n",
+    "print('Final mean topo', np.mean(vsim.topo))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eac525e4",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This PR:
- adds deposition of sediment from the rivers emptying in the sea
- switches the boundary status back to "all core" for the marine diffusion bit
- makes various other miscellaneous tweaks
- updates the notebook with a 1,000 year demo run, 1 year time step (small steps needed for depo!), that builds a ring of delta-like deposits around the island
- 